### PR TITLE
Print info about setting region as debug

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	if *region != "" {
 		defaults.DefaultConfig = defaults.DefaultConfig.WithRegion(*region).WithMaxRetries(10)
-		fmt.Println("Setting region:", defaults.DefaultConfig)
+		printDbg("Setting region:", defaults.DefaultConfig)
 		svc = s3.New(nil)
 	}
 


### PR DESCRIPTION
The region setting output rendered the first key in the bucket invalid,
printing it as debug should solve the issue.
